### PR TITLE
Fixed spacing/sizing for ultrawide and more

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -13,6 +13,10 @@ h1{
 }
 
 .main{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
   width: 100%;
   padding: 0;
   border: 0;
@@ -22,8 +26,8 @@ h1{
 }
 
 .page{
-  padding-top: 10%;
-  padding-bottom: 10%;
+  padding-top: 5%;
+  padding-bottom: 5%;
   width: 100%;
   box-sizing: border-box;
 }
@@ -32,6 +36,7 @@ h1{
   position: relative;
   width: 100%;
   height: 100%;
+  max-height: 90vh;
   background-color: #F5E8D6;
   padding: 3rem;
   box-sizing: border-box;
@@ -51,9 +56,11 @@ h1{
 }
 
 #links{
+  display: flex;
+  justify-content: space-evenly;
   margin: auto;
-  width: 100%;
-  padding: 15%;
+  width: 80%;
+  padding-top: 5%;
   padding-bottom: 5%;
 }
 


### PR DESCRIPTION
Resolves #4 

Changes
1. Fixed the viewing issue on ultra-wide monitors.
    1. You can still make it look like a bologna sandwich that your mom accidentally sat on, if you make the browser window very short and very wide (see Danny Devito). If you're customer obsessed, you can fix that on your own damn time.
1. Replaced whatever padding hocus pocus you had with some Flex (Tape).

Notes
1. Still looks like newborn wearing an adult diaper on mobile, but we can tackle that issue next quarantine.